### PR TITLE
docs: add JavaScript test-discovery recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Run a complete local quality gate with:
 
 ## Safe recipe catalog
 
-The repository includes five small workflows for repository inspection, test discovery, log inventory, port configuration, and proof of the read-only boundary. Every recipe is schema-versioned, inspect-only, network-free, write-free, bounded, and checked by the production policy before it can run.
+The repository includes six small workflows for repository inspection, Python and JavaScript test discovery, log inventory, port configuration, and proof of the read-only boundary. Every recipe is schema-versioned, inspect-only, network-free, write-free, bounded, and checked by the production policy before it can run.
 
 ```bash
 term-mcp recipe validate examples/recipes/*.json --workspace .

--- a/docs/GALLERY.md
+++ b/docs/GALLERY.md
@@ -31,6 +31,7 @@ The command, workspace, arguments, stdout, and stderr are absent from shared fix
 | --- | --- | --- | --- |
 | What is in this unfamiliar repository? | `term-mcp recipe run examples/recipes/inspect-repository.json --workspace .` | inspect, no network, no writes | [inspect-repository.json](../examples/recipes/inspect-repository.json) |
 | Where are the tests and their configuration? | `term-mcp recipe run examples/recipes/diagnose-tests.json --workspace .` | inspect, no network, no writes | [diagnose-tests.json](../examples/recipes/diagnose-tests.json) |
+| Which JavaScript or TypeScript test surfaces are present? | `term-mcp recipe run examples/recipes/discover-javascript-tests.json --workspace /path/to/js-project` | inspect, no network, no writes | [discover-javascript-tests.json](../examples/recipes/discover-javascript-tests.json) |
 | Which local log files exist? | `term-mcp recipe run examples/recipes/analyze-logs.json --workspace .` | inspect, no network, no writes | [analyze-logs.json](../examples/recipes/analyze-logs.json) |
 | Do service-port declarations agree? | `term-mcp recipe run examples/recipes/verify-port-config.json --workspace .` | inspect, no network, no writes | [verify-port-config.json](../examples/recipes/verify-port-config.json) |
 | Does the public catalog stay inside the read-only boundary? | `term-mcp recipe run examples/recipes/read-only-boundary.json --workspace .` | inspect, no network, no writes | [read-only-boundary.json](../examples/recipes/read-only-boundary.json) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,7 @@ The [proof gallery](../docs/GALLERY.md) pairs these recipes with complete sharin
 | --- | --- |
 | `inspect-repository` | What state and tracked surface does this repository have? |
 | `diagnose-tests` | Where is the test configuration and what test files exist? |
+| `discover-javascript-tests` | Which JavaScript or TypeScript test scripts, runner configuration, and test files are present? |
 | `analyze-logs` | Which local log files are available for a later bounded review? |
 | `verify-port-config` | Do environment and container files agree on the service port? |
 | `read-only-boundary` | Can the engine produce receipts without write or network permission? |

--- a/examples/recipes/discover-javascript-tests.json
+++ b/examples/recipes/discover-javascript-tests.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0",
+  "id": "discover-javascript-tests",
+  "title": "Discover JavaScript and TypeScript test configuration",
+  "intent": "Locate declared test scripts, common runner configuration, and test files without executing project code.",
+  "prerequisites": [
+    "rg is installed in a trusted system path",
+    "The workspace root contains package.json with at least one test-related entry",
+    "At least one listed JavaScript or TypeScript test configuration or test file exists"
+  ],
+  "permissions": {"mode": "inspect", "network": false, "writes": false},
+  "risk": "low",
+  "limits": {"timeout_seconds": 10, "max_output_bytes": 131072},
+  "steps": [
+    {
+      "name": "Read declared test configuration",
+      "command": "rg -n test package.json",
+      "expected_status": "succeeded"
+    },
+    {
+      "name": "Inventory test configuration and test files",
+      "command": "rg --files -g jest.config.* -g vitest.config.* -g playwright.config.* -g cypress.config.* -g .mocharc.* -g tsconfig*.json -g *.test.js -g *.test.jsx -g *.test.ts -g *.test.tsx -g *.spec.js -g *.spec.jsx -g *.spec.ts -g *.spec.tsx",
+      "expected_status": "succeeded"
+    }
+  ],
+  "expected_output": "Signed receipts identify package test declarations and matching configuration or test files without running them.",
+  "sample_receipt": {
+    "sharing_redacted": true,
+    "status": "succeeded",
+    "risk": "low",
+    "command": "[REDACTED FOR SHARING]",
+    "cwd": "[REDACTED FOR SHARING]",
+    "stdout": "[REDACTED FOR SHARING]",
+    "stderr": "[REDACTED FOR SHARING]"
+  }
+}

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -10,7 +10,7 @@ RECIPE_ROOT = Path(__file__).parents[1] / "examples" / "recipes"
 def test_all_public_recipes_are_strict_and_safe():
     paths = sorted(RECIPE_ROOT.glob("*.json"))
 
-    assert len(paths) == 5
+    assert len(paths) == 6
     assert all(validate_recipe(load_recipe(path), Path.cwd()) == [] for path in paths)
 
 


### PR DESCRIPTION
## Summary

- add an inspect-only recipe for discovering JavaScript and TypeScript test surfaces
- use two existing read-only `rg` commands without invoking Node, package managers, or project code
- register the sixth public recipe in the catalog, proof gallery, and recipe-count test

Fixes #9

## Safety boundary

- mode remains `inspect`
- network and writes remain disabled
- every step is validated as low risk by the production `CommandPolicy`
- prerequisites explicitly require a root `package.json`, a test declaration, and at least one matching config or test file

## Validation

- `ruff format --check .`: passed
- `ruff check .`: passed
- focused recipe and gallery tests: 5 passed
- temporary JavaScript fixture: recipe validation and both execution steps passed with low-risk signed receipts
- full Windows test run: 82 passed, 12 existing platform failures; coverage 73.8%. The failures require Linux/macOS commands such as `bash`, `touch`, and `npm`, matching the repository's documented supported development hosts.
